### PR TITLE
Correction in pixscale calculation (i.e. fix in WCS FITS keywords CDELT1,2) 

### DIFF
--- a/src/pacer_imager.cpp
+++ b/src/pacer_imager.cpp
@@ -547,7 +547,7 @@ Images CPacerImager::run_imager(Visibilities &xcorr, int n_pixels, double min_uv
     images.pixscale.resize(images.nFrequencies);
     for(size_t f {0}; f < images.nFrequencies; f++){
         double wavelength_m = VEL_LIGHT / frequencies[f];
-        images.pixscale[f] = 1.00/(2.00*(u_max/wavelength_m));
+        images.pixscale[f] = (1.00/(2.00*u_max))*(180.00/M_PI); // pixscale in degrees is later used in WCS FITS keywords CDELT1,2 
     }
     return images;
 }


### PR DESCRIPTION
Correction in pixscale calculation (removed wavelength in meters and added conversion from radians to degrees).
Fixes WCS FITS keywords CDELT1 and CDELT2.
The wavelength is not present to have the same pixscale at all frequencies (same as in multi-frequency synthesis). Can be thought of as all frequencies being referenced to a wavelength of 1m.