### PR TITLE
Implements the ability to image different polarisation products

### DIFF
--- a/build_imager.sh
+++ b/build_imager.sh
@@ -95,7 +95,7 @@ echo "Building the software.."
 cd ${build_dir}
 cmake .. -DCMAKE_INSTALL_PREFIX=${INSTALL_DIR} -DCMAKE_CXX_COMPILER=hipcc -DUSE_HIP=ON  -DCMAKE_BUILD_TYPE=Release-DCMAKE_CXX_FLAGS=-O3 ${cmake_options}
 make -j 12 VERBOSE=1
-
+make test
 # Install the software
 make install
 

--- a/build_imager.sh
+++ b/build_imager.sh
@@ -54,7 +54,7 @@ if [[ -n "$6" && "$6" != "-" ]]; then
    PROGRAM_NAME="$6"
 fi
 
-PROGRAM_VERSION=cleanup
+PROGRAM_VERSION=main
 if [[ -n "$7" && "$7" != "-" ]]; then
    PROGRAM_VERSION="$7"
 fi
@@ -75,8 +75,7 @@ echo "############################################"
 # - "group": install the software in the group wide directory
 # - "user": install the software only for the current user
 # - "test": install the software in the current working directory 
-echo "process_build_script_input user"
-process_build_script_input user 
+process_build_script_input user
 
 
 # load all the modules required for the program to compile and run.
@@ -85,13 +84,10 @@ process_build_script_input user
 echo "Loading required modules ..."
 echo "Loading modules for PAWSEY_CLUSTER = $PAWSEY_CLUSTER"
    module reset
-   # 12.1.0 -> 12.2.0
-   # was msfitslib/master-b37lvzx -> msfitslib/devel
-   module use /software/setonix/unsupported
-  module_load blink_test_data/devel cfitsio/4.1.0  msfitslib/master-ddop32m  blink-astroio/master fftw/3.3.10 pal/0.9.8-yyskiux libnova/0.15.0-pnwjlam rocm/6.2.4 # lfile2corrmatrix/devel
+  module_load blink_test_data/devel cfitsio/4.4.0  msfitslib/master-ittkjmq  blink-astroio/master fftw/3.3.10  pal/0.9.8-n3thcaw  libnova/0.15.0-iwh6cpn rocm/6.4.1 # lfile2corrmatrix/devel
    
    # cmake is only required at build time, so we use the normal module load
-   module load cmake/3.27.7
+   module load cmake/3.30.5
 # build your software..
 echo "Building the software.."
 
@@ -104,15 +100,6 @@ make -j 12 VERBOSE=1
 make install
 
 # test:
-if [[ $dotests -gt 0 ]]; then
-   echo "make test"
-   make test
-   cd $MYSCRATCH
-   calcfits_bg test_imager_gpu/start_time_1592584200_int_00_coarse_133_fine_ch00_image_real.fits = test_imager_gpu_ref/start_time_1592584200_int_00_coarse_133_fine_ch00_image_real.fits
-
-else
-   echo "WARNING : tests are not required"
-fi   
 
 echo "Create the modulefile in $MODULEFILE_DIR (or $INSTALL_DIR)"
 export ADDITIONAL_MODULEFILE_COMMANDS="prepend_path('BLINK_IMAGER_PATH', root_dir )"

--- a/src/corrections.cpp
+++ b/src/corrections.cpp
@@ -20,17 +20,18 @@ void apply_geometric_corrections_cpu(Visibilities &xcorr, const MemoryBuffer<flo
                     double angle = 2.0 * M_PI * w * frequencies[fine_channel] / SPEED_OF_LIGHT;
                     double sin_angle, cos_angle;
                     sincos(angle, &sin_angle, &cos_angle);
+                    for(int pol_idx {0}; pol_idx < 4; pol_idx++){ // TODO: avoid hardcoding 4 here..
+                        std::complex<VISIBILITY_TYPE> *vis = xcorr.at(time_step, fine_channel, ant1, ant2) + pol_idx;
 
-                    std::complex<VISIBILITY_TYPE> *vis = xcorr.at(time_step, fine_channel, ant1, ant2);
+                        double re = vis[0].real();
+                        double im = vis[0].imag();
 
-                    double re = vis[0].real();
-                    double im = vis[0].imag();
+                        double re_prim = re * cos_angle - im * sin_angle;
+                        double im_prim = im * cos_angle + re * sin_angle;
 
-                    double re_prim = re * cos_angle - im * sin_angle;
-                    double im_prim = im * cos_angle + re * sin_angle;
-
-                    std::complex<double> vis_new(re_prim, im_prim);
-                    *vis = vis_new;
+                        std::complex<double> vis_new(re_prim, im_prim);
+                        *vis = vis_new;
+                    }
                 }
             }
         }
@@ -55,16 +56,17 @@ void apply_cable_lengths_corrections_cpu(Visibilities &xcorr, const MemoryBuffer
 
                     double sin_angle, cos_angle;
                     sincos(angle, &sin_angle, &cos_angle);
+                    for(int pol_idx {0}; pol_idx < 4; pol_idx++){ // TODO: avoid hardcoding 4 here..
+                        std::complex<VISIBILITY_TYPE> *vis = xcorr.at(time_step, fine_channel, ant1, ant2) + pol_idx;
 
-                    std::complex<VISIBILITY_TYPE> *vis = xcorr.at(time_step, fine_channel, ant1, ant2);
+                        double re = vis[0].real();
+                        double im = vis[0].imag();
+                        double re_prim = re * cos_angle - im * sin_angle;
+                        double im_prim = im * cos_angle + re * sin_angle;
 
-                    double re = vis[0].real();
-                    double im = vis[0].imag();
-                    double re_prim = re * cos_angle - im * sin_angle;
-                    double im_prim = im * cos_angle + re * sin_angle;
-
-                    std::complex<double> vis_new(re_prim, im_prim);
-                    *vis = vis_new;
+                        std::complex<double> vis_new(re_prim, im_prim);
+                        *vis = vis_new;
+                    }
                 }
             }
         }

--- a/src/gpu/corrections_gpu.cpp
+++ b/src/gpu/corrections_gpu.cpp
@@ -17,23 +17,24 @@ __global__ void apply_cable_corrections(float *visibilities, unsigned int n_base
       unsigned int m_idx = i / n_baselines;
       unsigned int fine_channel = m_idx % n_frequencies;
 
-      double re = visibilities[i * 2 * n_pols_prod];
-      double im = visibilities[i * 2 * n_pols_prod + 1];
+      for(int pol_idx {0}; pol_idx < n_pols_prod; pol_idx++){
+         double re = visibilities[i * 2 * n_pols_prod + 2*pol_idx];
+         double im = visibilities[i * 2 * n_pols_prod + 2*pol_idx + 1];
 
-      unsigned int a1 {static_cast<unsigned int>(-0.5 + sqrt(0.25 + 2*baseline))};
-      unsigned int a2 {baseline - ((a1 + 1) * a1)/2};
+         unsigned int a1 {static_cast<unsigned int>(-0.5 + sqrt(0.25 + 2*baseline))};
+         unsigned int a2 {baseline - ((a1 + 1) * a1)/2};
 
-      double cableDeltaLen = (cable_lengths[a2] - cable_lengths[a1]);
-      double angle = -2.0*M_PI*cableDeltaLen*frequencies[fine_channel] / speed_of_light;
-      double sin_angle,cos_angle;
-      sincos(angle, &sin_angle, &cos_angle);
-      
-      double re_prim = re*cos_angle - im*sin_angle;
-      double im_prim = im*cos_angle + re*sin_angle;
+         double cableDeltaLen = (cable_lengths[a2] - cable_lengths[a1]);
+         double angle = -2.0*M_PI*cableDeltaLen*frequencies[fine_channel] / speed_of_light;
+         double sin_angle,cos_angle;
+         sincos(angle, &sin_angle, &cos_angle);
+         
+         double re_prim = re*cos_angle - im*sin_angle;
+         double im_prim = im*cos_angle + re*sin_angle;
 
-      visibilities[i * 2 * n_pols_prod] = re_prim;
-      visibilities[i * 2 * n_pols_prod + 1] = im_prim;
-      
+         visibilities[i * 2 * n_pols_prod+ 2*pol_idx] = re_prim;
+         visibilities[i * 2 * n_pols_prod + 2*pol_idx + 1] = im_prim;
+      }
    }
 }
 
@@ -49,22 +50,24 @@ __global__ void apply_geometric_corrections(float *visibilities, unsigned int n_
       unsigned int baseline = i % n_baselines;
       unsigned int m_idx = i / n_baselines;
       unsigned int fine_channel = m_idx % n_frequencies;
-
-      double re = visibilities[i * 2 * n_pols_prod];
-      double im = visibilities[i * 2 * n_pols_prod + 1];
       
-      unsigned int a1 {static_cast<unsigned int>(-0.5 + sqrt(0.25 + 2*baseline))};
-      unsigned int a2 {baseline - ((a1 + 1) * a1)/2};
-      // TODO this will have to change once we save w on a lower triangular matrix basis
-      double angle = 2.0 * M_PI *  w[a1 * n_ant + a2] * frequencies[fine_channel] / speed_of_light;
-      double sin_angle,cos_angle;
-      sincos(angle, &sin_angle, &cos_angle);
-      
-      double re_prim = re*cos_angle - im*sin_angle;
-      double im_prim = im*cos_angle + re*sin_angle;
-      
-      visibilities[i * 2 * n_pols_prod] = re_prim;
-      visibilities[i * 2 * n_pols_prod + 1] = im_prim;
+      for(int pol_idx {0}; pol_idx < n_pols_prod; pol_idx++){
+         double re = visibilities[i * 2 * n_pols_prod + 2*pol_idx];
+         double im = visibilities[i * 2 * n_pols_prod + 2*pol_idx + 1];
+         
+         unsigned int a1 {static_cast<unsigned int>(-0.5 + sqrt(0.25 + 2*baseline))};
+         unsigned int a2 {baseline - ((a1 + 1) * a1)/2};
+         // TODO this will have to change once we save w on a lower triangular matrix basis
+         double angle = 2.0 * M_PI *  w[a1 * n_ant + a2] * frequencies[fine_channel] / speed_of_light;
+         double sin_angle,cos_angle;
+         sincos(angle, &sin_angle, &cos_angle);
+         
+         double re_prim = re*cos_angle - im*sin_angle;
+         double im_prim = im*cos_angle + re*sin_angle;
+         
+         visibilities[i * 2 * n_pols_prod + 2*pol_idx] = re_prim;
+         visibilities[i * 2 * n_pols_prod + 2*pol_idx + 1] = im_prim;
+      }
    }
 }
 

--- a/src/gpu/gridding_gpu.h
+++ b/src/gpu/gridding_gpu.h
@@ -5,7 +5,7 @@
 #include <gpu_fft.hpp>
 #include <astroio.hpp>
 #include <memory_buffer.hpp>
-
+#include "../gridding.hpp"
 
 
 
@@ -14,7 +14,7 @@ void gridding_gpu(const Visibilities& xcorr,
       const MemoryBuffer<int>& antenna_flags, const MemoryBuffer<float>& antenna_weights,
       const MemoryBuffer<double>& frequencies,
       double delta_u, double delta_v,
-      int n_pixels, double min_uv, MemoryBuffer<float>& grids_counters,
+      int n_pixels, double min_uv, Polarization pol, MemoryBuffer<float>& grids_counters,
       MemoryBuffer<std::complex<float>>& grids);
 
 #endif 

--- a/src/gpu/pacer_imager_hip.cpp
+++ b/src/gpu/pacer_imager_hip.cpp
@@ -13,7 +13,8 @@
 
 #include "../utils.h"
 
-CPacerImagerHip::CPacerImagerHip(const std::string metadata_file, const std::vector<int>& flagged_antennas, bool average_images) : CPacerImager(metadata_file, flagged_antennas, average_images) {}
+CPacerImagerHip::CPacerImagerHip(const std::string metadata_file, const std::vector<int>& flagged_antennas, 
+   bool average_images, Polarization pol_to_image) : CPacerImager(metadata_file, flagged_antennas, average_images, pol_to_image) {}
 
 void CPacerImagerHip::UpdateAntennaFlags(int n_ant) {
    if(!antenna_flags_gpu){
@@ -69,7 +70,7 @@ Images CPacerImagerHip::gridding_imaging(Visibilities& xcorr,
    gpuMemcpy(v_gpu.data(),  v_cpu.data(), sizeof(float)*xySize, gpuMemcpyHostToDevice);
 
    gridding_gpu(xcorr, u_gpu, v_gpu, antenna_flags_gpu, antenna_weights_gpu, frequencies_gpu,
-      delta_u, delta_v, n_pixels, min_uv, grids_counters, grids);
+      delta_u, delta_v, n_pixels, min_uv, pol_to_image, grids_counters, grids);
 
    gpuEvent_t start, stop;
    gpuEventCreate(&start);

--- a/src/gpu/pacer_imager_hip.h
+++ b/src/gpu/pacer_imager_hip.h
@@ -56,7 +56,7 @@ protected :
 
 
 public :
-   CPacerImagerHip(const std::string metadata_file, const std::vector<int>& flagged_antennas, bool average_images = false);
+   CPacerImagerHip(const std::string metadata_file, const std::vector<int>& flagged_antennas, bool average_images = false, Polarization pol_to_image = Polarization::XX);
 };
 
 

--- a/src/gridding.hpp
+++ b/src/gridding.hpp
@@ -1,0 +1,6 @@
+#ifndef __GRIDDING_H__
+#define __GRIDDING_H__
+
+enum class Polarization {XX, YY, I};
+
+#endif

--- a/src/pacer_imager.cpp
+++ b/src/pacer_imager.cpp
@@ -88,8 +88,9 @@ int CPacerImager::UpdateFlags()
 }
 
 
-CPacerImager::CPacerImager(const std::string metadata_file, const std::vector<int>& flagged_antennas, bool average_images) {
+CPacerImager::CPacerImager(const std::string metadata_file, const std::vector<int>& flagged_antennas, bool average_images, Polarization pol_to_image) {
     this->average_images = average_images;
+    this->pol_to_image = pol_to_image;
      // read all information from metadata
     if (metadata_file.length() > 0 && MyFile::DoesFileExist(metadata_file.c_str())) {
         PRINTF_INFO("INFO : reading meta data from file %s\n", metadata_file.c_str());

--- a/src/pacer_imager.cpp
+++ b/src/pacer_imager.cpp
@@ -316,11 +316,22 @@ void CPacerImager::gridding_fast(Visibilities &xcorr, MemoryBuffer<std::complex<
                             }
                         }
 
-                        std::complex<float> *vis = xcorr.at(time_step, fine_channel, ant1,
-                                                            ant2); // was ant1, ant2 , but ant2,ant1 does not fix
-                                                                   // the orientation of the final image either ...
-                        double re = vis->real();                   // fits_vis_real.getXY(ant1,ant2);
-                        double im = vis->imag();                   // fits_vis_imag.getXY(ant1,ant2);
+                        double re {0}, im {0};
+                        if(pol_to_image == Polarization::XX){
+                            std::complex<float> *vis_xx = xcorr.at(time_step, fine_channel, ant1, ant2);
+                            re = vis_xx->real();
+                            im = vis_xx->imag();
+                        }else if(pol_to_image == Polarization::YY){
+                            std::complex<float> *vis_yy = xcorr.at(time_step, fine_channel, ant1, ant2) + 3;
+                            re =  vis_yy->real();
+                            im =  vis_yy->imag();
+                        }else {
+                            // Stokes I
+                            std::complex<float> *vis_xx = xcorr.at(time_step, fine_channel, ant1, ant2);
+                            std::complex<float> *vis_yy = vis_xx + 3;
+                            re = vis_xx->real() + vis_yy->real();
+                            im = vis_xx->imag() + vis_yy->imag();
+                        }
 
                         if (!isnan(re) && !isnan(im))
                         {

--- a/src/pacer_imager.h
+++ b/src/pacer_imager.h
@@ -16,6 +16,8 @@ using namespace std;
 // AstroIO for Visibilities class :
 #include <astroio.hpp>
 #include <memory_buffer.hpp>
+
+#include "gridding.hpp"
 // #define VISIBILITY_TYPE double // visibility type currently double but may be float 
 // forward declaration of class  Visibilities, the header file is included in pacer_imager.cpp
 // class  Visibilities;
@@ -78,8 +80,9 @@ public :
    double m_PixscaleAtZenith;
    double pixsize_in_radians;
    
+   Polarization pol_to_image;
 
-   CPacerImager(const std::string metadata_file, const std::vector<int>& flagged_antennas, bool average_images = false);
+   CPacerImager(const std::string metadata_file, const std::vector<int>& flagged_antennas, bool average_images = false, Polarization pol_to_image = Polarization::XX);
    
    // Set / Get functions :
    //-----------------------------------------------------------------------------------------------------------------------------

--- a/tests/gridding_test.cpp
+++ b/tests/gridding_test.cpp
@@ -38,7 +38,7 @@ void test_gridding_gpu(){
     MemoryBuffer<float> grids_counters(buffer_size, true);
     MemoryBuffer<std::complex<float>> grids(buffer_size,  true);
     gridding_gpu(xcorr, u_buff, v_buff, antenna_flags, antenna_weights, frequencies,
-      delta_u, delta_v, n_pixels, min_uv, grids_counters, grids);
+      delta_u, delta_v, n_pixels, min_uv, Polarization::XX, grids_counters, grids);
 
     grids_counters.to_cpu();
     grids.to_cpu();


### PR DESCRIPTION
The imager constructor now accepts an additional argument of type `Polarization`, defined in `gridding.hpp`.
`Polarization` is an `enum class` which can takes the following self-explanatory values: `XX`, `YY`, and `I`.

The value is saved in a class member attribute, and it is then passed down to the gridding routines.

In the gridding kernels, we check which polarization product we want to grid. `XX` is a complex value
whose components are at offset 0 and 1 in a baseline correlation products matrix. `YY` complex
components are at position 6 and 7. For Stokes I, the code adds up the correspoding real and imaginary
parts before gridding.

A note on the `gridding.hpp` file. I have introduced it because in the future I intend to decouple
the CPU gridding routines from the imager class, pretty much like I did for the GPU versions.
See `src/gridding_gpu.*`.

@marcinsokolowski  This current branch passes the imager tests, which means it correctly image the XX polarisation (default option). I yet have to modify the pipeline project to support this and test it with the observations, but feel free to compile this branch and try it out on your own too.

I want to wait to merge this until I have tested it properly.