### PR TITLE
Adds the oversampling parameter to the imager.

### DIFF
--- a/src/gpu/pacer_imager_hip.cpp
+++ b/src/gpu/pacer_imager_hip.cpp
@@ -13,8 +13,9 @@
 
 #include "../utils.h"
 
-CPacerImagerHip::CPacerImagerHip(const std::string metadata_file, const std::vector<int>& flagged_antennas, 
-   bool average_images, Polarization pol_to_image) : CPacerImager(metadata_file, flagged_antennas, average_images, pol_to_image) {}
+CPacerImagerHip::CPacerImagerHip(const std::string metadata_file, const std::vector<int>& flagged_antennas,
+   bool average_images, Polarization pol_to_image, float oversampling_factor) : CPacerImager(
+      metadata_file, flagged_antennas, average_images, pol_to_image, oversampling_factor) {}
 
 void CPacerImagerHip::UpdateAntennaFlags(int n_ant) {
    if(!antenna_flags_gpu){

--- a/src/gpu/pacer_imager_hip.h
+++ b/src/gpu/pacer_imager_hip.h
@@ -56,7 +56,8 @@ protected :
 
 
 public :
-   CPacerImagerHip(const std::string metadata_file, const std::vector<int>& flagged_antennas, bool average_images = false, Polarization pol_to_image = Polarization::XX);
+   CPacerImagerHip(const std::string metadata_file, const std::vector<int>& flagged_antennas, bool average_images = false,
+      Polarization pol_to_image = Polarization::XX, float oversampling_factor = 2.0f);
 };
 
 

--- a/src/pacer_imager.h
+++ b/src/pacer_imager.h
@@ -60,6 +60,7 @@ public :
   bool apply_geom_correction {true};
   bool apply_cable_correction {true};
   bool average_images {false};
+  float oversampling_factor {2.0f};
 
    // meta data :
    CObsMetadata m_MetaData;
@@ -87,7 +88,8 @@ public :
    double m_fFrequencyMHz {-1};
    
 
-   CPacerImager(const std::string metadata_file, const std::vector<int>& flagged_antennas, bool average_images = false, Polarization pol_to_image = Polarization::XX);
+   CPacerImager(const std::string metadata_file, const std::vector<int>& flagged_antennas, bool average_images = false,
+      Polarization pol_to_image = Polarization::XX, float oversampling_factor = 2.0f);
    
    // Set / Get functions :
    //-----------------------------------------------------------------------------------------------------------------------------


### PR DESCRIPTION
Addresses issue #10.

I added the `oversampling_factor` class attribute to the imager, as well as a constructor parameter to pass a specific oversampling factor. Default value is 2.

Will need to implement an option in the pipeline to specify the oversampling factor through command line. This will be useful when processing SMART data, where we would be using an oversampling factor of 5.