### PR TITLE
Implements the Stokes I convention used by other imagers.

### DIFF
--- a/src/gpu/gridding_gpu.cpp
+++ b/src/gpu/gridding_gpu.cpp
@@ -74,7 +74,7 @@ __global__ void gridding_kernel(const float *visibilities, unsigned int n_baseli
       unsigned int m_idx = i / n_baselines;
       unsigned int fine_channel = m_idx % n_frequencies;
 
-      double re {0}, im {0};
+      float re {0}, im {0};
 
       if(pol == Polarization::XX){
          re = visibilities[i * 2 * n_pols_prod];
@@ -84,8 +84,8 @@ __global__ void gridding_kernel(const float *visibilities, unsigned int n_baseli
          im = visibilities[i * 2 * n_pols_prod + 7];
       }else {
          // Stokes I
-         re = visibilities[i * 2 * n_pols_prod] + visibilities[i * 2 * n_pols_prod + 6];
-         im = visibilities[i * 2 * n_pols_prod + 1] + visibilities[i * 2 * n_pols_prod + 7];
+         re = (visibilities[i * 2 * n_pols_prod] + visibilities[i * 2 * n_pols_prod + 6]) / 2.0f;
+         im = (visibilities[i * 2 * n_pols_prod + 1] + visibilities[i * 2 * n_pols_prod + 7]) / 2.0f;
       }
       
       unsigned int a1 {static_cast<unsigned int>(-0.5 + sqrt(0.25 + 2*baseline))};

--- a/src/pacer_imager.cpp
+++ b/src/pacer_imager.cpp
@@ -319,7 +319,7 @@ void CPacerImager::gridding_fast(Visibilities &xcorr, MemoryBuffer<std::complex<
                             }
                         }
 
-                        double re {0}, im {0};
+                        float re {0}, im {0};
                         if(pol_to_image == Polarization::XX){
                             std::complex<float> *vis_xx = xcorr.at(time_step, fine_channel, ant1, ant2);
                             re = vis_xx->real();
@@ -332,8 +332,8 @@ void CPacerImager::gridding_fast(Visibilities &xcorr, MemoryBuffer<std::complex<
                             // Stokes I
                             std::complex<float> *vis_xx = xcorr.at(time_step, fine_channel, ant1, ant2);
                             std::complex<float> *vis_yy = vis_xx + 3;
-                            re = vis_xx->real() + vis_yy->real();
-                            im = vis_xx->imag() + vis_yy->imag();
+                            re = (vis_xx->real() + vis_yy->real()) / 2.0f;
+                            im = (vis_xx->imag() + vis_yy->imag()) / 2.0f;
                         }
 
                         if (!isnan(re) && !isnan(im))


### PR DESCRIPTION
In this PR I implement the changes to have Stokes I = (XX + YY) / 2. As discussed in person, we would like to be as close as possible to other imagers, even though the (XX + YY) convention is scientifically correct.

This commit solves #14.