### PR TITLE
Implements long exposure imaging

### DIFF
--- a/apps/pacer_imager_main.cpp
+++ b/apps/pacer_imager_main.cpp
@@ -510,7 +510,7 @@ int main(int argc,char* argv[])
   CPacerImagerHip imager;   
 #else
   printf("DEBUG0 : pol_to_image = %d\n", int(gImagerParameters.pol_to_image) );
-  CPacerImager imager( gImagerParameters.m_MetaDataFile.c_str(), gFlaggedAntennasList, false, gImagerParameters.pol_to_image ) ;
+  CPacerImager imager( gImagerParameters.m_MetaDataFile.c_str(), gImageSize, gFlaggedAntennasList, false, gImagerParameters.pol_to_image ) ;
 #endif  
   
   gImagerParameters.SetGlobalParameters( gAntennaPositionsFile.c_str(), (gZenithImage) ); // Constant UVW when zenith image (-Z)
@@ -574,7 +574,7 @@ int main(int argc,char* argv[])
      
      imager.m_nConvolvingKernelSize = gImagerParameters.m_nConvolvingKernelSize;
      imager.m_fFrequencyMHz = gFrequencyMHz;
-     Images image = imager.run_imager( (*xcorr), gImageSize, -1000, "" );
+     Images image = imager.run( (*xcorr));
      image.to_fits_files( gOutputDirectory.c_str() );
   
 /*       imager.run_imager( in_basename.c_str(),  gPostfix.c_str(), 

--- a/src/gpu/corrections_gpu.cpp
+++ b/src/gpu/corrections_gpu.cpp
@@ -76,7 +76,7 @@ void apply_cable_lengths_corrections_gpu(Visibilities &xcorr, MemoryBuffer<doubl
    if(!xcorr.on_gpu()) xcorr.to_gpu();
    cable_lengths.to_gpu();
    frequencies.to_gpu();
-   int n_baselines = (xcorr.obsInfo.nAntennas + 1) * (xcorr.obsInfo.nAntennas / 2);
+   int n_baselines = ((xcorr.obsInfo.nAntennas + 1) * xcorr.obsInfo.nAntennas) / 2;
    struct gpuDeviceProp_t props;
    int gpu_id = -1;
    gpuGetDevice(&gpu_id);
@@ -90,7 +90,7 @@ void apply_cable_lengths_corrections_gpu(Visibilities &xcorr, MemoryBuffer<doubl
 void apply_geometric_corrections_gpu(Visibilities &xcorr, float *w_gpu, MemoryBuffer<double>& frequencies){
    xcorr.to_gpu();
    frequencies.to_gpu();
-   int n_baselines = (xcorr.obsInfo.nAntennas + 1) * (xcorr.obsInfo.nAntennas / 2);
+   int n_baselines = ((xcorr.obsInfo.nAntennas + 1) * xcorr.obsInfo.nAntennas) / 2;
    struct gpuDeviceProp_t props;
    int gpu_id = -1;
    gpuGetDevice(&gpu_id);

--- a/src/gpu/gpu_utils.cpp
+++ b/src/gpu/gpu_utils.cpp
@@ -152,10 +152,10 @@ __global__ void averaging_kernel(const Complex<float> *data, size_t n_pixels, si
 
  Images image_averaging_gpu(const Images& images){
    size_t image_size = images.image_size();
-   size_t n_images = images.integration_intervals() * images.nFrequencies;
+   size_t n_images = images.size();
    MemoryBuffer<std::complex<float>> avg_image {image_size, true};
    unsigned int n_blocks {static_cast<unsigned int>((image_size + NTHREADS - 1) / NTHREADS)};
    averaging_kernel<<<n_blocks, NTHREADS>>>(reinterpret_cast<const Complex<float>*>(images.data()), image_size, n_images, reinterpret_cast<Complex<float>*>(avg_image.data()));
    gpuCheckLastError();
-   return {std::move(avg_image), images.obsInfo, images.obsInfo.nTimesteps, images.obsInfo.nFrequencies, images.side_size};
+   return {std::move(avg_image), images.obsInfo, 1, 1, images.side_size};
  }

--- a/src/gpu/gpu_utils.cpp
+++ b/src/gpu/gpu_utils.cpp
@@ -157,5 +157,5 @@ __global__ void averaging_kernel(const Complex<float> *data, size_t n_pixels, si
    unsigned int n_blocks {static_cast<unsigned int>((image_size + NTHREADS - 1) / NTHREADS)};
    averaging_kernel<<<n_blocks, NTHREADS>>>(reinterpret_cast<const Complex<float>*>(images.data()), image_size, n_images, reinterpret_cast<Complex<float>*>(avg_image.data()));
    gpuCheckLastError();
-   return {std::move(avg_image), images.obsInfo, 1, 1, images.side_size};
+   return {std::move(avg_image), images.obsInfo, 1, 1, images.side_size, images.ra_deg, images.dec_deg, images.pixscale_ra, images.pixscale_dec};
  }

--- a/src/gpu/gridding_gpu.cpp
+++ b/src/gpu/gridding_gpu.cpp
@@ -129,17 +129,13 @@ void gridding_gpu(const Visibilities& xcorr,
       double delta_u, double delta_v,
       int n_pixels, double min_uv, Polarization pol, MemoryBuffer<float>& grids_counters,
       MemoryBuffer<std::complex<float>>& grids){
-  std::cout << "Running 'gridding' on GPU.." << std::endl;
 
   int n_ant = xcorr.obsInfo.nAntennas;
   int image_size {n_pixels * n_pixels}; 
 
    size_t n_images {xcorr.integration_intervals() * xcorr.nFrequencies};
    size_t buffer_size {image_size * n_images};
-   
-   gpuMemset(grids_counters.data(), 0, grids_counters.size() * sizeof(float));
-   gpuMemset(grids.data(), 0, grids.size() * sizeof(std::complex<float>));
-   
+      
    int n_baselines = (xcorr.obsInfo.nAntennas + 1) * (xcorr.obsInfo.nAntennas / 2);
    struct gpuDeviceProp_t props;
    int gpu_id = -1;
@@ -150,4 +146,5 @@ void gridding_gpu(const Visibilities& xcorr,
       n_ant, u_gpu.data(), v_gpu.data(), antenna_flags.data(), antenna_weights.data(), frequencies.data(), image_size,
       delta_u, delta_v, n_pixels, grids_counters.data(), min_uv, pol, (gpufftComplex*) grids.data());
    gpuGetLastError();
+   gpuDeviceSynchronize();
 }

--- a/src/gpu/gridding_gpu.cpp
+++ b/src/gpu/gridding_gpu.cpp
@@ -136,7 +136,7 @@ void gridding_gpu(const Visibilities& xcorr,
    size_t n_images {xcorr.integration_intervals() * xcorr.nFrequencies};
    size_t buffer_size {image_size * n_images};
       
-   int n_baselines = (xcorr.obsInfo.nAntennas + 1) * (xcorr.obsInfo.nAntennas / 2);
+   int n_baselines = ((xcorr.obsInfo.nAntennas + 1) * xcorr.obsInfo.nAntennas) / 2;
    struct gpuDeviceProp_t props;
    int gpu_id = -1;
    gpuGetDevice(&gpu_id);

--- a/src/gpu/pacer_imager_hip.cpp
+++ b/src/gpu/pacer_imager_hip.cpp
@@ -13,9 +13,9 @@
 
 #include "../utils.h"
 
-CPacerImagerHip::CPacerImagerHip(const std::string metadata_file, const std::vector<int>& flagged_antennas,
-   bool average_images, Polarization pol_to_image, float oversampling_factor) : CPacerImager(
-      metadata_file, flagged_antennas, average_images, pol_to_image, oversampling_factor) {}
+CPacerImagerHip::CPacerImagerHip(const std::string metadata_file, int n_pixels, const std::vector<int>& flagged_antennas,
+   bool average_images, Polarization pol_to_image, float oversampling_factor, double min_uv, const char *weighting) : CPacerImager(
+      metadata_file, n_pixels, flagged_antennas, average_images, pol_to_image, oversampling_factor, min_uv, weighting) {}
 
 void CPacerImagerHip::UpdateAntennaFlags(int n_ant) {
    if(!antenna_flags_gpu){
@@ -38,47 +38,53 @@ void CPacerImagerHip::UpdateAntennaFlags(int n_ant) {
 }
 
 
-// TODO : 
-//     - do more cleanup of this function as this is nearly "RAW" copy paste from Gayatri's code:
-//     - optimise (same in CPU version) uv_grid_counter, uv_grid_real, uv_grid_imag to become member variables.
-Images CPacerImagerHip::gridding_imaging(Visibilities& xcorr,
-                                     double delta_u, double delta_v,
-                                     int    n_pixels,
-                                     double min_uv /*=-1000*/,    // minimum UV 
-                                     const char* weighting)
-{
-  std::cout << "Running 'gridding_imaging' on GPU.." << std::endl;
+void CPacerImagerHip::gridding(Visibilities& xcorr){
+  std::cout << "Running 'gridding' on GPU.." << std::endl;
 
   int n_ant = xcorr.obsInfo.nAntennas;
   int xySize = n_ant * n_ant;
-  int image_size {n_pixels * n_pixels}; 
+  int image_size {n_pixels * n_pixels};
+   size_t n_images {n_gridded_channels * n_gridded_intervals};
+   size_t buffer_size {image_size * n_images};
 
   // update antenna flags before gridding which uses these flags or weights:
   UpdateAntennaFlags( n_ant );
-
-   size_t n_images{xcorr.integration_intervals() * xcorr.nFrequencies};
-   size_t buffer_size {image_size * n_images};
-   if(!grids_counters) grids_counters.allocate(image_size * xcorr.nFrequencies, true);
-   if(!grids) grids.allocate(buffer_size, true);
-   MemoryBuffer<std::complex<float>> images_buffer(buffer_size, true);
-   if(!frequencies_gpu) frequencies_gpu.allocate(xcorr.nFrequencies, true);
-   gpuMemcpy(frequencies_gpu.data(), frequencies.data(), frequencies.size() * sizeof(double), gpuMemcpyHostToDevice);
-   if(!u_gpu) {
+  if(!u_gpu) {
       u_gpu.allocate(xySize, true);
       v_gpu.allocate(xySize, true);
    }
    gpuMemcpy(u_gpu.data(),  u_cpu.data(), sizeof(float)*xySize, gpuMemcpyHostToDevice);
    gpuMemcpy(v_gpu.data(),  v_cpu.data(), sizeof(float)*xySize, gpuMemcpyHostToDevice);
 
-   gridding_gpu(xcorr, u_gpu, v_gpu, antenna_flags_gpu, antenna_weights_gpu, frequencies_gpu,
-      delta_u, delta_v, n_pixels, min_uv, pol_to_image, grids_counters, grids);
+   if(!grids_counters) {
+      grids_counters.allocate(image_size * xcorr.nFrequencies, true);
+      gpuMemset(grids_counters.data(), 0, grids_counters.size() * sizeof(float));
+   }
+   if(!grids) {
+      grids.allocate(buffer_size, true);
+      gpuMemset(grids.data(), 0, grids.size() * sizeof(std::complex<float>));
+   }
+   if(!frequencies_gpu) frequencies_gpu.allocate(xcorr.nFrequencies, true);
+   gpuMemcpy(frequencies_gpu.data(), frequencies.data(), frequencies.size() * sizeof(double), gpuMemcpyHostToDevice);
+   
 
+   gridding_gpu(xcorr, u_gpu, v_gpu, antenna_flags_gpu, antenna_weights_gpu, frequencies_gpu,
+      delta_u, delta_v, n_pixels, min_uv, pol_to_image, grids_counters, grids);   
+}
+
+
+
+Images CPacerImagerHip::image(ObservationInfo& obs_info){
+   if(!grids_counters || !grids) throw std::runtime_error {"Grids are not initialised and cannot be imaged."};
+   int image_size {n_pixels * n_pixels};
+   size_t n_images {n_gridded_channels * n_gridded_intervals};
+   size_t buffer_size {image_size * n_images};
+
+   MemoryBuffer<std::complex<float>> images_buffer(buffer_size, true);
    gpuEvent_t start, stop;
    gpuEventCreate(&start);
    gpuEventCreate(&stop);
    float elapsed;
-       
-
     if( !m_FFTPlan ){
        int n[2]; 
        n[0] = n_pixels; 
@@ -96,17 +102,31 @@ Images CPacerImagerHip::gridding_imaging(Visibilities& xcorr,
      gpuEventSynchronize(stop);
      gpuEventElapsedTime(&elapsed, start, stop);
      std::cout << "gpufftExecC2C took " << elapsed << "ms" << std::endl;
-     if(!fnorm) fnorm.allocate(xcorr.nFrequencies, true);
-     vector_sum_gpu(grids_counters.data(), image_size, xcorr.nFrequencies, fnorm);
-     fft_shift_and_norm_gpu( (gpufftComplex*) images_buffer.data(), n_pixels, n_pixels, n_images, fnorm );
-     Images imgs {std::move(images_buffer), xcorr.obsInfo, xcorr.nIntegrationSteps, xcorr.nAveragedChannels, static_cast<unsigned int>(n_pixels)};
-      gpuEventDestroy(start);
+    gpuEventDestroy(start);
      gpuEventDestroy(stop);
+     
+     if(!fnorm) fnorm.allocate(n_gridded_channels, true);
+     vector_sum_gpu(grids_counters.data(), image_size, n_gridded_channels, fnorm);
+     fft_shift_and_norm_gpu( (gpufftComplex*) images_buffer.data(), n_pixels, n_pixels, n_images, fnorm );
+     // reset grids for the next round of imaging
+     gpuMemset(grids_counters.data(), 0, grids_counters.size() * sizeof(float));
+     gpuMemset(grids.data(), 0, grids.size() * sizeof(std::complex<float>));
+   
+     Images images {std::move(images_buffer), obs_info,static_cast<unsigned int>(n_gridded_intervals), 
+        static_cast<unsigned int>(n_gridded_channels), static_cast<unsigned int>(n_pixels)};
+     
+    images.ra_deg = m_MetaData.raHrs*15.00;
+    images.dec_deg = m_MetaData.decDegs;
+    // MAX(u) , pixscale in degrees is later used in WCS FITS keywords CDELT1,2
+    images.pixscale_ra = (1.00/(oversampling_factor*u_max))*(180.00/M_PI);
+    // MAX(v) , pixscale in degrees is later used in WCS FITS keywords CDELT1,2
+    images.pixscale_dec = (1.00/(oversampling_factor*v_max))*(180.00/M_PI);
      if(average_images){
-          return image_averaging_gpu(imgs);
+          return image_averaging_gpu(images);
      }else{
-          return imgs;
+          return images;
      }
+
 }
 
 

--- a/src/gpu/pacer_imager_hip.cpp
+++ b/src/gpu/pacer_imager_hip.cpp
@@ -111,16 +111,18 @@ Images CPacerImagerHip::image(ObservationInfo& obs_info){
      // reset grids for the next round of imaging
      gpuMemset(grids_counters.data(), 0, grids_counters.size() * sizeof(float));
      gpuMemset(grids.data(), 0, grids.size() * sizeof(std::complex<float>));
-   
-     Images images {std::move(images_buffer), obs_info,static_cast<unsigned int>(n_gridded_intervals), 
-        static_cast<unsigned int>(n_gridded_channels), static_cast<unsigned int>(n_pixels)};
-     
-    images.ra_deg = m_MetaData.raHrs*15.00;
-    images.dec_deg = m_MetaData.decDegs;
+
+     double ra_deg = m_MetaData.raHrs*15.00;
+     double dec_deg = m_MetaData.decDegs;
     // MAX(u) , pixscale in degrees is later used in WCS FITS keywords CDELT1,2
-    images.pixscale_ra = (1.00/(oversampling_factor*u_max))*(180.00/M_PI);
+    double pixscale_ra = (1.00/(oversampling_factor*u_max))*(180.00/M_PI);
     // MAX(v) , pixscale in degrees is later used in WCS FITS keywords CDELT1,2
-    images.pixscale_dec = (1.00/(oversampling_factor*v_max))*(180.00/M_PI);
+    double pixscale_dec = (1.00/(oversampling_factor*v_max))*(180.00/M_PI);
+
+     Images images {std::move(images_buffer), obs_info,static_cast<unsigned int>(n_gridded_intervals), 
+        static_cast<unsigned int>(n_gridded_channels), static_cast<unsigned int>(n_pixels),
+         ra_deg, dec_deg, pixscale_ra, pixscale_dec};
+     
      if(average_images){
           return image_averaging_gpu(images);
      }else{

--- a/src/gpu/pacer_imager_hip.h
+++ b/src/gpu/pacer_imager_hip.h
@@ -43,21 +43,17 @@ protected :
    //          - uv_grid_real, uv_grid_imag : visibilities on UV grid (real and imag arrays)
    //          - uv_grid_counter : visibility counter and 
    //-----------------------------------------------------------------------------------------------------------------------------
-   virtual Images gridding_imaging( Visibilities& xcorr, 
-                  double delta_u, double delta_v,
-                  int    n_pixels,
-                  double min_uv=-1000,    // minimum UV 
-                  const char* weighting="");
-
+   virtual void gridding(Visibilities& xcorr);
     // virtual function to NOT DO corrections in CPU but in GPU :
     virtual void ApplyGeometricCorrections( Visibilities& xcorr, MemoryBuffer<float>& w_cpu, MemoryBuffer<double>& frequencies);
    
     virtual void ApplyCableCorrections(Visibilities& xcorr, MemoryBuffer<double>& cable_lengths, MemoryBuffer<double>& frequencies);
 
 
-public :
-   CPacerImagerHip(const std::string metadata_file, const std::vector<int>& flagged_antennas, bool average_images = false,
-      Polarization pol_to_image = Polarization::XX, float oversampling_factor = 2.0f);
+public:
+   virtual Images image(ObservationInfo& obsInfo);
+   CPacerImagerHip(const std::string metadata_file, int n_pixels, const std::vector<int>& flagged_antennas, bool average_images = false,
+      Polarization pol_to_image = Polarization::XX, float oversampling_factor = 2.0f, double min_uv = -1000, const char* weighting = "");
 };
 
 

--- a/src/pacer_imager.cpp
+++ b/src/pacer_imager.cpp
@@ -132,7 +132,7 @@ void fft_shift(std::complex<float>* image, size_t image_x_side, size_t image_y_s
 
 // Based on example :
 // https://github.com/AccelerateHS/accelerate-examples/blob/master/examples/fft/src-fftw/FFTW.c
-Images CPacerImager::image(ObservationInfo& obsInfo) {
+Images CPacerImager::image(ObservationInfo& obs_info) {
     if(!grids_counters || !grids) throw std::runtime_error {"Grids are not initialised and cannot be imaged."};
     size_t buffer_size {n_pixels * n_pixels * n_gridded_intervals * n_gridded_channels};
     MemoryBuffer<std::complex<float>> images_buffer {buffer_size};
@@ -188,15 +188,17 @@ Images CPacerImager::image(ObservationInfo& obsInfo) {
     // TODO : re-grid to SKY COORDINATES !!!
     // convert cos(alpha) to alpha - see notes !!!
     // how to do it ???
-    Images images {std::move(images_buffer), obsInfo, static_cast<unsigned int>(n_gridded_intervals),
-        static_cast<unsigned int>(n_gridded_channels), static_cast<unsigned int>(n_pixels)};
-
-    images.ra_deg = m_MetaData.raHrs*15.00;
-    images.dec_deg = m_MetaData.decDegs;
+    double ra_deg = m_MetaData.raHrs*15.00;
+     double dec_deg = m_MetaData.decDegs;
     // MAX(u) , pixscale in degrees is later used in WCS FITS keywords CDELT1,2
-    images.pixscale_ra = (1.00/(oversampling_factor*u_max))*(180.00/M_PI);
+    double pixscale_ra = (1.00/(oversampling_factor*u_max))*(180.00/M_PI);
     // MAX(v) , pixscale in degrees is later used in WCS FITS keywords CDELT1,2
-    images.pixscale_dec = (1.00/(oversampling_factor*v_max))*(180.00/M_PI);
+    double pixscale_dec = (1.00/(oversampling_factor*v_max))*(180.00/M_PI);
+
+     Images images {std::move(images_buffer), obs_info,static_cast<unsigned int>(n_gridded_intervals), 
+        static_cast<unsigned int>(n_gridded_channels), static_cast<unsigned int>(n_pixels),
+         ra_deg, dec_deg, pixscale_ra, pixscale_dec};
+    
      if(average_images){
           return image_averaging_cpu(images);
      }else{
@@ -554,7 +556,7 @@ void CPacerImager::grid(Visibilities& xcorr){
     // MWA TEST
     //     delta_u = 1.00/(n_pixels*delta_theta);
     //     delta_v = 1.00/(n_pixels*delta_theta);
-    PRINTF_DEBUG("delta_u = %.8f (u_max = %.8f), delta_v = %.8f (v_max = %.8f), "
+    printf("delta_u = %.8f (u_max = %.8f), delta_v = %.8f (v_max = %.8f), "
                     "calculated as 1/FoV = 1/(%d pixels * %.5f rad), delta_theta = %.5f "
                     "[deg]\n",
                     delta_u, u_max, delta_v, v_max, n_pixels, pixsize_in_radians, pixsize_in_radians * (180.00 / M_PI));

--- a/src/utils.cpp
+++ b/src/utils.cpp
@@ -17,7 +17,8 @@ Images image_averaging_cpu(const Images& images){
     for(size_t i {0}; i < image_size; i++){
         avg_image[i].real(avg_image[i].real() / static_cast<float>(n_images));
     }
-   return {std::move(avg_image), images.obsInfo, 1, 1, images.side_size};
+   return {std::move(avg_image), images.obsInfo, 1, 1, images.side_size, 
+    images.ra_deg, images.dec_deg, images.pixscale_ra, images.pixscale_dec};
 }
 
 

--- a/src/utils.cpp
+++ b/src/utils.cpp
@@ -3,7 +3,7 @@
 
 Images image_averaging_cpu(const Images& images){
     size_t image_size = images.image_size();
-    size_t n_images = images.integration_intervals() * images.nFrequencies;
+    size_t n_images = images.n_intervals * images.n_channels;
     MemoryBuffer<std::complex<float>> avg_image {image_size};
     memset(avg_image.data(), 0, sizeof(std::complex<float>) * image_size);
     for(size_t img_id {0}; img_id < n_images; img_id++){
@@ -17,8 +17,7 @@ Images image_averaging_cpu(const Images& images){
     for(size_t i {0}; i < image_size; i++){
         avg_image[i].real(avg_image[i].real() / static_cast<float>(n_images));
     }
-    printf("avg = %f\n", avg_image[0].real());
-   return {std::move(avg_image), images.obsInfo, images.obsInfo.nTimesteps, images.obsInfo.nFrequencies, images.side_size};
+   return {std::move(avg_image), images.obsInfo, 1, 1, images.side_size};
 }
 
 

--- a/tests/gpu_utils_test.cpp
+++ b/tests/gpu_utils_test.cpp
@@ -107,7 +107,7 @@ void test_averaging_kernel(){
     }
     for(int i {0}; i < n_pixels; i++) reference_avg_data[i] /= n_images;
     input_images_data.to_gpu();
-    Images input_images  {std::move(input_images_data), VCS_OBSERVATION_INFO, VCS_OBSERVATION_INFO.nTimesteps, VCS_OBSERVATION_INFO.nFrequencies / n_images, image_side};
+    Images input_images  {std::move(input_images_data), VCS_OBSERVATION_INFO, 2, 2, image_side};
     Images avg_image = image_averaging_gpu(input_images);
     std::cerr << "Invocation over." << std::endl;
     avg_image.to_cpu();

--- a/tests/gpu_utils_test.cpp
+++ b/tests/gpu_utils_test.cpp
@@ -107,7 +107,7 @@ void test_averaging_kernel(){
     }
     for(int i {0}; i < n_pixels; i++) reference_avg_data[i] /= n_images;
     input_images_data.to_gpu();
-    Images input_images  {std::move(input_images_data), VCS_OBSERVATION_INFO, 2, 2, image_side};
+    Images input_images  {std::move(input_images_data), VCS_OBSERVATION_INFO, 2, 2, image_side, 0, 0, 0, 0};
     Images avg_image = image_averaging_gpu(input_images);
     std::cerr << "Invocation over." << std::endl;
     avg_image.to_cpu();

--- a/tests/gridding_test.cpp
+++ b/tests/gridding_test.cpp
@@ -39,6 +39,8 @@ void test_gridding_gpu(){
     size_t buffer_size {n_pixels * n_pixels * n_images};
     MemoryBuffer<float> grids_counters(buffer_size, true);
     MemoryBuffer<std::complex<float>> grids(buffer_size,  true);
+    gpuMemset(grids_counters.data(), 0, grids_counters.size() * sizeof(float));
+    gpuMemset(grids.data(), 0, grids.size() * sizeof(std::complex<float>));
     gridding_gpu(xcorr, u_buff, v_buff, antenna_flags, antenna_weights, frequencies,
       delta_u, delta_v, n_pixels, min_uv, Polarization::XX, grids_counters, grids);
 

--- a/tests/imager_test.cpp
+++ b/tests/imager_test.cpp
@@ -48,32 +48,33 @@ void test_imager_common(CPacerImager& imager, bool is_cpu){
     std::string antennaPositionsFile {""};
     std::string output_dir { is_cpu ? 
         "test_imager_cpu/" : "test_imager_gpu/"};
-    std::string szWeighting {"N"};
-    const int image_size = 256;
-    bool bZenithImage {false};
-    double fUnixTime {1592584200};
-    double MinUV = -1000;
-    double FOV_degrees = 30;
 
    ObservationInfo obs_info {VCS_OBSERVATION_INFO};
    auto xcorr = Visibilities::from_fits_file(vis_file, obs_info);
-   auto images = imager.run_imager(xcorr,image_size, MinUV, szWeighting.c_str());
+   if(!is_cpu) xcorr.to_gpu();
+   auto images = imager.run(xcorr);
    std::cout << "Saving images to disk..." << std::endl;
    images.to_fits_files(output_dir);
 }
 
 void test_imager_cpu(){
+    std::string szWeighting {"N"};
+    const int image_size = 256;
+    double MinUV = -1000;
     std::string metadataFile {dataRootDir + "/mwa/1276619416/20200619163000.metafits"};
     std::vector<int> flagged_antennas {21, 25, 58, 71, 80, 81, 92, 101, 108, 114, 119, 125};
-    CPacerImager imager {metadataFile, flagged_antennas};
+    CPacerImager imager {metadataFile, image_size, flagged_antennas, false, Polarization::XX, 2.0f, MinUV, szWeighting.c_str()};
     test_imager_common(imager, true);
 }
 
 #ifdef __GPU__
 void test_imager_gpu(){
+    std::string szWeighting {"N"};
+    const int image_size = 256;
+    double MinUV = -1000;
     std::string metadataFile {dataRootDir + "/mwa/1276619416/20200619163000.metafits"};
     std::vector<int> flagged_antennas {21, 25, 58, 71, 80, 81, 92, 101, 108, 114, 119, 125};
-    CPacerImagerHip imager {metadataFile, flagged_antennas};
+    CPacerImagerHip imager {metadataFile, image_size, flagged_antennas, false, Polarization::XX, 2.0f, MinUV, szWeighting.c_str()};
     test_imager_common(imager, false);
 }
 #endif


### PR DESCRIPTION
Hi @marcinsokolowski, I know this looks like a big change in the codebase, but it is just reshuffling the existing code in fewer, decoupled functions.

With this PR I implement support for long exposure imaging (as well as keeping support for fast imaging of course). Here is the message from the related commit reported here for clarity.

The imager has now three public methods, `run`, `grid`, and `image`.
The `run` method simply calls `grid` and then `image`, implementing
the default behaviour the imager had up until this commit. That is,
visibilities are gridded and then imaged straight away.

Now, the grid method can be called multiple times, allowing the
caller to grid multiple coarse channels and seconds on the same
grid before it is imaged. This implements the long exposure imaging
feature.

There is still work to do. Different intervals and fine channels
in the same .dat file, or xcorr structure, are gridded on separate
grids. In long exposure mode, we only want to grid on a single grid.
Hence, we need a constructor arugment called `long_exposure` that
signals the imager class that it should run in long exposure mode.

Other changes to the code comprise moving arguments of `run_imager`
to the constructor, such as `n_pixels`.